### PR TITLE
refactor stretch goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,5 @@ and should receive an additional 5%.
 ---
 
 ## Stretch Goals
-- Put the output on the DOM (visually on the page).
-- Make the app run only after the user clicks on a button on the page
-- Then style the output, making it visually appealing.
+- Create a diagram, flowchart, or some other visual aid that **documents** the logic you've just implemented.
+  - The more you practice this skill, the more you become an awesome communicator of algorithmic logic. This is a *superpower* that you can develop during your time at Prime, but you'll neet to commit to practicing it.


### PR DESCRIPTION
Related to this [tweak](https://github.com/PrimeAcademy/prime-curriculum-syllabus/commit/3286f53603915eaddf25861f7bfcbc5e9b185299) that I made to the `week-06-overview.md` file.

All that's really needed is to remove the stretch goal, but I thought this would be a cool alternative we could occasionally throw at them if y'all are into it. 🙂